### PR TITLE
Remove dev package from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "array-bounds": "^1.0.1",
     "array-normalize": "^1.1.3",
     "binary-search-bounds": "^2.0.4",
-    "bubleify": "^1.1.0",
     "clamp": "^1.0.1",
     "dtype": "^2.0.0",
     "flatten-vertex-data": "^1.0.0",
@@ -53,6 +52,7 @@
   },
   "devDependencies": {
     "almost-equal": "^1.1.0",
+    "bubleify": "^1.1.0",
     "canvas-fit": "^1.5.0",
     "gauss-random": "^1.0.1",
     "math-float64-bits": "^1.0.1",


### PR DESCRIPTION
Bubleify and its dependencies do not need to be distributed with this package.