### PR TITLE
dependencies: Remove array-normalize, regl; move bubleify to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "array-bounds": "^1.0.1",
     "binary-search-bounds": "^2.0.4",
-    "bubleify": "^1.1.0",
     "clamp": "^1.0.1",
     "defined": "^1.0.0",
     "dtype": "^2.0.0",
@@ -54,6 +53,7 @@
   },
   "devDependencies": {
     "almost-equal": "^1.1.0",
+    "bubleify": "^1.1.0",
     "canvas-fit": "^1.5.0",
     "gauss-random": "^1.0.1",
     "math-float64-bits": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "license": "MIT",
   "dependencies": {
     "array-bounds": "^1.0.1",
-    "array-normalize": "^1.1.4",
     "binary-search-bounds": "^2.0.4",
     "bubleify": "^1.1.0",
     "clamp": "^1.0.1",
@@ -60,7 +59,6 @@
     "math-float64-bits": "^1.0.1",
     "math-float64-from-bits": "^1.0.0",
     "math-uint8-bits": "^1.0.0",
-    "regl": "^1.3.1",
     "snap-points-2d": "^3.2.0",
     "tape": "^4.8.0"
   }


### PR DESCRIPTION
`array-normalize` and `regl` are unused. `bubleify` is only used for building `demo/index.html`, which is not part of the NPM package.